### PR TITLE
Esto debería mejorar bastante la velocidad del modelo

### DIFF
--- a/dsgd/DSModelMultiQ.py
+++ b/dsgd/DSModelMultiQ.py
@@ -66,8 +66,9 @@ class DSModelMultiQ(nn.Module):
         # replace rules that don't apply with ones
         qt[sel] = 1
         res = qt.prod(1)
+        res2 = res.clone()
+        res[res2.sum(1) <= 1e-16] += 1e-16
         out = res / res.sum(1, keepdim=True)
-        # TODO do the 1e-16 fix
         return out
 
     def clear_rmap(self):


### PR DESCRIPTION
Todavía faltan algunas cosas eso sí. Por ejemplo, como cambié la función select_rules por otra, el rmap no se va a poblar automáticamente con el entrenamiento. Ahí tienes que decidir si eliminarlo o poblarlo intencionalmente. Por el motivo anterior, no funciona el ejemplo del breast cancer, ya que el main intenta usar directamente el rmap. La función select_rules tuya no la he eliminado porque se usa en varias partes además de forward. Deberíamos ver qué hacer al respecto.

Además, ya no tiene mucho sentido el flag "precompute_rules" porque la matriz de r x n booleanos se hará igual.